### PR TITLE
Gradle 7 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ repositories {
 }
 
 dependencies {
-	compile 'org.neo4j.driver:neo4j-java-driver:4.1.1'
-	compile 'com.google.protobuf:protobuf-java:3.13.0'
+	implementation 'org.neo4j.driver:neo4j-java-driver:4.1.1'
+	implementation 'com.google.protobuf:protobuf-java:3.13.0'
 }
 
 //----------------------START "DO NOT MODIFY" SECTION------------------------------


### PR DESCRIPTION
The `compile` directive has been deprecated since [Gradle 4](https://docs.gradle.org/4.10/userguide/java_plugin.html#sec:java_plugin_and_dependency_management) and has been removed in Gradle 7.

Also, awesome work. Love this plugin!